### PR TITLE
Use Nucleus api + Support multiple commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build
+.idea
+.gradle
+*.jar

--- a/build.gradle
+++ b/build.gradle
@@ -10,9 +10,16 @@ ext {
     completeversion = "-s${spongeapiversion.substring(0, 3)}-v${activetimeversion}"
 }
 
+repositories {
+    maven {
+        name = 'nucleus-api'
+        url = 'http://repo.drnaylor.co.uk/artifactory/list/minecraft'
+    }
+}
+
 dependencies {
-    compile fileTree(dir: 'libs', include: '*.jar')
     compile "org.spongepowered:spongeapi:${spongeapiversion}"
+    compile 'io.github.nucleuspowered:nucleus-api:1.2.3-SNAPSHOT-S7.0'
 }
 
 jar {

--- a/src/main/java/com/mcsimonflash/sponge/activetime/ActiveTime.java
+++ b/src/main/java/com/mcsimonflash/sponge/activetime/ActiveTime.java
@@ -6,7 +6,6 @@ import com.mcsimonflash.sponge.activetime.commands.*;
 import com.mcsimonflash.sponge.activetime.managers.Config;
 import com.mcsimonflash.sponge.activetime.managers.NucleusIntegration;
 import com.mcsimonflash.sponge.activetime.managers.Util;
-import io.github.nucleuspowered.nucleus.Nucleus;
 import org.slf4j.Logger;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.args.GenericArguments;
@@ -20,14 +19,17 @@ import org.spongepowered.api.event.game.state.GameInitializationEvent;
 import org.spongepowered.api.event.game.state.GamePostInitializationEvent;
 import org.spongepowered.api.event.game.state.GameStartedServerEvent;
 import org.spongepowered.api.event.network.ClientConnectionEvent;
+import org.spongepowered.api.plugin.Dependency;
 import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.text.Text;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.Optional;
 
-@Plugin(id = "activetime", name = "ActiveTime", version = "1.3.2", authors = "Simon_Flash")
+@Plugin(id = "activetime", name = "ActiveTime", version = "1.3.2", authors = "Simon_Flash", dependencies = @Dependency(id="nucleus", optional = true))
 public class ActiveTime {
 
     private static ActiveTime plugin;
@@ -116,7 +118,8 @@ public class ActiveTime {
 
     @Listener
     public void onPostInit(GamePostInitializationEvent event) {
-        if (Sponge.getPluginManager().isLoaded("nucleus") && Nucleus.getNucleus().isModuleLoaded("afk")) {
+        Optional<PluginContainer> nucleus = Sponge.getPluginManager().getPlugin("nucleus");
+        if (nucleus.isPresent()) {
             nucleusEnabled = true;
             NucleusIntegration.updateAFKService();
             NucleusIntegration.RegisterMessageToken();

--- a/src/main/java/com/mcsimonflash/sponge/activetime/objects/Milestone.java
+++ b/src/main/java/com/mcsimonflash/sponge/activetime/objects/Milestone.java
@@ -6,23 +6,28 @@ import com.mcsimonflash.sponge.activetime.managers.Util;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.Player;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class Milestone {
 
     private String name;
     private int activetime;
-    private String command;
+    private List<String> commands;
 
-    public Milestone(String name, int activetime, String command) {
+    public Milestone(String name, int activetime, List<String> commands) {
         this.name = name;
         this.activetime = activetime;
-        this.command = command;
+        this.commands = commands;
     }
 
     public void process(Player player, int time) {
         if (time >= activetime && !Storage.hasMilestone(player.getUniqueId(), name)) {
             if (Storage.setMilestone(player.getUniqueId(), name, true)) {
-                String modifiedCommand = command.replace("<player>", player.getName()).replace("<activetime>", Integer.toString(time));
-                Util.createTask("ActiveTime GiveMilestone Sync Processor (" + player.getName() + ")", task -> Sponge.getCommandManager().process(Sponge.getServer().getConsole(), modifiedCommand), 0, false);
+                for (String command : commands) {
+                    String modifiedCommand = command.replace("<player>", player.getName()).replace("<activetime>", Integer.toString(time));
+                    Util.createTask("ActiveTime GiveMilestone Sync Processor (" + player.getName() + ")", task -> Sponge.getCommandManager().process(Sponge.getServer().getConsole(), modifiedCommand), 0, false);
+                }
             } else {
                 ActiveTime.getPlugin().getLogger().error("Unable to save obtained milestone! | Milestone:[" + name + "] Player:[" + player + "]");
             }


### PR DESCRIPTION
Maintains support for legacy command string as well as supporting this
```
ten-hours {
    activetime=36000
    commands=[
    	"broadcast &b<player>&f has played on our server for &b10hours&f!",
    	"lp user <player> parent add regular"
	]
}
```

Removes need for jar in libs and uses api instead